### PR TITLE
Fix update secret not showing add/update properly

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -78,6 +78,7 @@ func (c *Collection) DeleteSecret(name string) (Secret, error) {
 func (c *Collection) UpdateSecret(name, value string) (Secret, error) {
 	var retSecret Secret
 	var err error
+	var ok bool
 
 	if len(name) == 0 {
 		err = errSecretNameEmpty
@@ -86,7 +87,7 @@ func (c *Collection) UpdateSecret(name, value string) (Secret, error) {
 	} else {
 		_, err = totp.GenerateCode(value, time.Now())
 		if err == nil {
-			retSecret, ok := c.Secrets[name]
+			retSecret, ok = c.Secrets[name]
 			if ok == true {
 				retSecret.Value = value
 				retSecret.DateModified = time.Now()

--- a/collection_test.go
+++ b/collection_test.go
@@ -135,6 +135,10 @@ func TestSettingsNew(t *testing.T) {
 	if err != nil {
 		t.Error("Error updating secret", secret, err)
 	}
+	if secret.DateAdded == secret.DateModified {
+		t.Error("Date modified not updated on secret update")
+	}
+
 	secret, err = c.GetSecret(testSecret)
 	if err != nil || secret.Value != newSecret {
 		t.Error("Failed to update secret")


### PR DESCRIPTION
When using update/add secret, the printed result always reflects that it was added even when only updated. Resolved and added a test for it.