### PR TITLE
dependabot target branch to dev

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 5
+  target-branch: dev
 - package-ecosystem: github-actions
   directory: /
   schedule:


### PR DESCRIPTION
Change dependabot's target branch from default to `dev`.